### PR TITLE
Remove second parameter of the suggestion wizard

### DIFF
--- a/Classes/Tca/Form/SuggestWizard.php
+++ b/Classes/Tca/Form/SuggestWizard.php
@@ -27,10 +27,9 @@ class SuggestWizard {
 	 * Renders a suggestion for the mapping.
 	 *
 	 * @param array $PA
-	 * @param \TYPO3\CMS\Backend\Form\FormEngine $pObj
 	 * @return string
 	 */
-	public function render(array &$PA, \TYPO3\CMS\Backend\Form\FormEngine $pObj) {
+	public function render(array &$PA) {
 		$serverType = (int)$PA['row']['ldap_server'];
 
 		if (substr($PA['field'], -7) === '_basedn') {


### PR DESCRIPTION
It is not used in the function and the type hint causes errors in 7.6. It would have been an alternative to just remove the hint but to remove it completely imho lead to more understandable code.

gRTz
pekue